### PR TITLE
Replace uses of event_impl::getHandlerRef

### DIFF
--- a/sycl/unittests/buffer/BufferReleaseBase.cpp
+++ b/sycl/unittests/buffer/BufferReleaseBase.cpp
@@ -227,12 +227,12 @@ TEST_F(BufferDestructionCheck, ReadyToReleaseLogic) {
   ReadCmd =
       new MockCmdWithReleaseTracking(sycl::detail::getSyclObjImpl(Q), MockReq);
   // These dummy handles are automatically cleaned up by the runtime
-  ReadCmd->getEvent()->getHandleRef() = reinterpret_cast<ur_event_handle_t>(
-      mock::createDummyHandle<ur_event_handle_t>());
+  ReadCmd->getEvent()->setHandle( reinterpret_cast<ur_event_handle_t>(
+      mock::createDummyHandle<ur_event_handle_t>()));
   WriteCmd =
       new MockCmdWithReleaseTracking(sycl::detail::getSyclObjImpl(Q), MockReq);
-  WriteCmd->getEvent()->getHandleRef() = reinterpret_cast<ur_event_handle_t>(
-      mock::createDummyHandle<ur_event_handle_t>());
+  WriteCmd->getEvent()->setHandle( reinterpret_cast<ur_event_handle_t>(
+      mock::createDummyHandle<ur_event_handle_t>()) );
   ReadCmd->MEnqueueStatus = sycl::detail::EnqueueResultT::SyclEnqueueSuccess;
   WriteCmd->MEnqueueStatus = sycl::detail::EnqueueResultT::SyclEnqueueSuccess;
 
@@ -247,23 +247,23 @@ TEST_F(BufferDestructionCheck, ReadyToReleaseLogic) {
                                             &replaceEventGetInfo);
   testing::InSequence S;
 
-  ExpectedEventStatus[ReadCmd->getEvent()->getHandleRef()] =
+  ExpectedEventStatus[ReadCmd->getEvent()->getHandle()] =
       UR_EVENT_STATUS_SUBMITTED;
-  ExpectedEventStatus[WriteCmd->getEvent()->getHandleRef()] =
-      UR_EVENT_STATUS_SUBMITTED;
-
-  EXPECT_FALSE(MockSchedulerPtr->checkLeavesCompletion(Rec));
-
-  ExpectedEventStatus[ReadCmd->getEvent()->getHandleRef()] =
-      UR_EVENT_STATUS_COMPLETE;
-  ExpectedEventStatus[WriteCmd->getEvent()->getHandleRef()] =
+  ExpectedEventStatus[WriteCmd->getEvent()->getHandle()] =
       UR_EVENT_STATUS_SUBMITTED;
 
   EXPECT_FALSE(MockSchedulerPtr->checkLeavesCompletion(Rec));
 
-  ExpectedEventStatus[ReadCmd->getEvent()->getHandleRef()] =
+  ExpectedEventStatus[ReadCmd->getEvent()->getHandle()] =
       UR_EVENT_STATUS_COMPLETE;
-  ExpectedEventStatus[WriteCmd->getEvent()->getHandleRef()] =
+  ExpectedEventStatus[WriteCmd->getEvent()->getHandle()] =
+      UR_EVENT_STATUS_SUBMITTED;
+
+  EXPECT_FALSE(MockSchedulerPtr->checkLeavesCompletion(Rec));
+
+  ExpectedEventStatus[ReadCmd->getEvent()->getHandle()] =
+      UR_EVENT_STATUS_COMPLETE;
+  ExpectedEventStatus[WriteCmd->getEvent()->getHandle()] =
       UR_EVENT_STATUS_COMPLETE;
   EXPECT_TRUE(MockSchedulerPtr->checkLeavesCompletion(Rec));
   // previous expect_call is still valid and will generate failure if we recieve

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -190,7 +190,7 @@ TEST_F(SchedulerTest, StreamAUXCmdsWait) {
     ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
 
     auto EventImpl = std::make_shared<sycl::detail::event_impl>(QueueImpl);
-    EventImpl->getHandleRef() = UREvent;
+    EventImpl->setHandle(UREvent);
 
     QueueImplProxy->registerStreamServiceEvent(EventImpl);
 

--- a/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
+++ b/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
@@ -113,7 +113,7 @@ protected:
     ASSERT_EQ(PassedNumEvents.size(), 1u);
     auto [EventCount, EventArr] = PassedNumEvents[0];
     ASSERT_EQ(EventCount, 1u);
-    EXPECT_EQ(*EventArr, Cmd3Event->getHandleRef());
+    EXPECT_EQ(*EventArr, Cmd3Event->getHandle());
   }
 
   void VerifyBlockedCommandsEnqueue(
@@ -339,7 +339,7 @@ TEST_F(DependsOnTests, ShortcutFunctionWithWaitList) {
   });
   std::shared_ptr<detail::event_impl> SingleTaskEventImpl =
       detail::getSyclObjImpl(SingleTaskEvent);
-  EXPECT_EQ(SingleTaskEventImpl->getHandleRef(), nullptr);
+  EXPECT_EQ(SingleTaskEventImpl->getHandle(), nullptr);
 
   Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueSuccess;
   EventsInWaitList.clear();
@@ -352,9 +352,9 @@ TEST_F(DependsOnTests, ShortcutFunctionWithWaitList) {
                                             QueueDevImpl->get_context());
   auto ShortcutFuncEvent = Queue.memcpy(
       SecondBuf, FirstBuf, sizeof(int) * ArraySize, {SingleTaskEvent});
-  EXPECT_NE(SingleTaskEventImpl->getHandleRef(), nullptr);
+  EXPECT_NE(SingleTaskEventImpl->getHandle(), nullptr);
   ASSERT_EQ(EventsInWaitList.size(), 1u);
-  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl->getHandleRef());
+  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl->getHandle());
   Queue.wait();
   sycl::free(FirstBuf, Queue);
   sycl::free(SecondBuf, Queue);
@@ -381,15 +381,15 @@ TEST_F(DependsOnTests, BarrierWithWaitList) {
   });
   std::shared_ptr<detail::event_impl> SingleTaskEventImpl =
       detail::getSyclObjImpl(SingleTaskEvent);
-  EXPECT_EQ(SingleTaskEventImpl->getHandleRef(), nullptr);
+  EXPECT_EQ(SingleTaskEventImpl->getHandle(), nullptr);
 
   Cmd->MEnqueueStatus = detail::EnqueueResultT::SyclEnqueueSuccess;
   EventsInWaitList.clear();
 
   Queue.ext_oneapi_submit_barrier(std::vector<sycl::event>{SingleTaskEvent});
-  EXPECT_NE(SingleTaskEventImpl->getHandleRef(), nullptr);
+  EXPECT_NE(SingleTaskEventImpl->getHandle(), nullptr);
   ASSERT_EQ(EventsInWaitList.size(), 1u);
-  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl->getHandleRef());
+  EXPECT_EQ(EventsInWaitList[0], SingleTaskEventImpl->getHandle());
   Queue.wait();
 }
 } // anonymous namespace

--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -154,8 +154,8 @@ static void checkCleanupOnEnqueue(MockScheduler &MS,
 
   // Check addCopyBack
   MockCmd = addNewMockCmds();
-  LeafMockCmd->getEvent()->getHandleRef() =
-      reinterpret_cast<ur_event_handle_t>(new int{});
+  LeafMockCmd->getEvent()->setHandle(
+     reinterpret_cast<ur_event_handle_t>(new int{}));
   MS.addCopyBack(&MockReq);
   verifyCleanup(Record, AllocaCmd, MockCmd, CommandDeleted);
 

--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -119,7 +119,7 @@ TEST_F(SchedulerTest, InOrderQueueIsolatedDeps) {
   {
     event E1 = submitKernel(Q1);
     event E2 = submitKernel(Q2);
-    ExpectedEvent = detail::getSyclObjImpl(E2)->getHandleRef();
+    ExpectedEvent = detail::getSyclObjImpl(E2)->getHandle();
     Q1.ext_oneapi_submit_barrier({E1, E2});
     EXPECT_TRUE(BarrierCalled);
   }

--- a/sycl/unittests/scheduler/QueueFlushing.cpp
+++ b/sycl/unittests/scheduler/QueueFlushing.cpp
@@ -54,7 +54,7 @@ static void addDepAndEnqueue(detail::Command *Cmd,
 
   ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
 
-  DepCmd.getEvent()->getHandleRef() = UREvent;
+  DepCmd.getEvent()->setHandle(UREvent);
   (void)Cmd->addDep(detail::DepDesc{&DepCmd, &MockReq, nullptr}, ToCleanUp);
 
   detail::EnqueueResultT Res;
@@ -93,7 +93,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
   detail::QueueImplPtr QueueImplA = detail::getSyclObjImpl(QueueA);
   queue QueueB{Ctx, default_selector_v};
   detail::QueueImplPtr QueueImplB = detail::getSyclObjImpl(QueueB);
-  ExpectedDepQueue = QueueImplB->getHandleRef();
+  ExpectedDepQueue = QueueImplB->getHandle();
 
   int val;
   buffer<int, 1> Buf(&val, range<1>(1));
@@ -154,7 +154,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
     ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
 
-    DepEvent->getHandleRef() = UREvent;
+    DepEvent->setHandleRef(UREvent);
     (void)Cmd.addDep(DepEvent, ToCleanUp);
     MockScheduler::enqueueCommand(&Cmd, Res, detail::NON_BLOCKING);
     EXPECT_TRUE(QueueFlushed);
@@ -174,7 +174,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
       ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
 
-      DepEvent->getHandleRef() = UREvent;
+      DepEvent->setHandle(UREvent);
     }
     (void)Cmd.addDep(DepEvent, ToCleanUp);
     MockScheduler::enqueueCommand(&Cmd, Res, detail::NON_BLOCKING);
@@ -198,13 +198,13 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
     ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
 
-    DepCmdA.getEvent()->getHandleRef() = UREvent;
+    DepCmdA.getEvent()->setHandle(UREvent);
     (void)Cmd.addDep(detail::DepDesc{&DepCmdA, &MockReq, nullptr}, ToCleanUp);
     MockCommand DepCmdB(QueueImplB);
 
     UREvent = mock::createDummyHandle<ur_event_handle_t>();
 
-    DepCmdB.getEvent()->getHandleRef() = UREvent;
+    DepCmdB.getEvent()->setHandle(UREvent);
     (void)Cmd.addDep(detail::DepDesc{&DepCmdB, &MockReq, nullptr}, ToCleanUp);
     // The check is performed in redefinedQueueFlush
     MockScheduler::enqueueCommand(&Cmd, Res, detail::NON_BLOCKING);
@@ -219,7 +219,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
     ur_event_handle_t UREvent = mock::createDummyHandle<ur_event_handle_t>();
 
-    DepCmd.getEvent()->getHandleRef() = UREvent;
+    DepCmd.getEvent()->setHandle(UREvent);
     (void)CmdA.addDep(detail::DepDesc{&DepCmd, &MockReq, nullptr}, ToCleanUp);
     MockScheduler::enqueueCommand(&CmdA, Res, detail::NON_BLOCKING);
 


### PR DESCRIPTION
For modifying, use ``event_impl::setHandler``, for accessing use ``event_impl::get_Handler``.